### PR TITLE
250321

### DIFF
--- a/250321/gold5_1366.py
+++ b/250321/gold5_1366.py
@@ -1,0 +1,45 @@
+note = ['A', 'A#', 'B', 'C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#']
+N, M = map(int, input().split())
+guitar = list(input().split())
+chord = list(input().split())
+guitar_idx = []
+frets = []
+
+for g in guitar:
+    cur_fret = []
+    for c in chord:
+        chord_idx = note.index(c)
+        if chord_idx == note.index(g):
+            cur_fret.append(0)
+        else:
+            cur_fret.append((chord_idx - note.index(g)) % 12)
+    frets.append(cur_fret)
+
+print(frets)
+
+checked = [False] * N
+fret_candidates = [list(x) for x in zip(*frets)]
+final_fret = []
+
+for i in range(M):
+    final_fret.append(min(fret_candidates[i]))
+    checked[fret_candidates[i].index(min(fret_candidates[i]))] = True
+
+for i in range(N):
+    if checked[i] == True:
+        continue
+    else:
+        final_fret.append(min(frets[i]))
+
+min_fret = float('inf')
+max_fret = 0
+
+for f in final_fret:
+    if f != 0:
+        if f < min_fret:
+            min_fret = f
+        elif f > max_fret:
+            max_fret = f
+
+print(max_fret, min_fret)
+print(max_fret - min_fret + 1)

--- a/250321/silver2_11501.py
+++ b/250321/silver2_11501.py
@@ -1,0 +1,29 @@
+import sys
+from collections import deque
+input = sys.stdin.readline
+
+def sol():
+    N = int(input())
+    stocks = deque(list(map(int, input().split())))
+    gain = 0
+    max_price = 0
+    # max_stock = max(stocks)
+    # while stocks:
+    #     cur_stock = stocks.popleft()
+
+    #     if cur_stock < max_stock:
+    #         gain += max_stock - cur_stock
+    #     else:
+    #         max_stock = max(stocks) if stocks else 0
+    
+    for i in range(N-1, -1, -1):
+        if stocks[i] > max_price:
+            max_price = stocks[i]
+        else:
+            gain += max_price - stocks[i]
+    
+    return gain
+
+T = int(input())
+for _ in range(T):
+    print(sol())


### PR DESCRIPTION
# 11051 주식 - solved
### 접근 방식 
- 처음에는 전체 stocks 리스트에서 max를 pop하여, max의 index 전까지의 이익을 계산하며 stocks 리스트가 빌 때까지 반복하는 방식으로 구현

    -> 리스트를 순회하며 max를 찾기 위해 한 번 더 순회 필요함 = O(N^2) 으로 시간초과
- 리스트를 한 번만 순회할 수 있도록 뒤에서부터 순회해가며 max() 함수를 사용하지 않고 max_price 갱신 가능하도록 로직 변경

    ->테케 하나당 O(N)으로 시간복잡도 개선

### 시공간 복잡도 (테케 하나당)
- 시간복잡도: O(N)   // 리스트 순회 1번
- 공간복잡도: O(N)      // 리스트


---

# 1366 기타코드 - missed

## 접근방식
- 각 줄에 대한 전체 코드의 프랫 list 생성
- 각 코드 별 최소 프랫을 뽑아냄
- 코드를 다 눌렀으니, 아직 눌리지 않은 줄은 그 줄의 min 프랫을 누르도록 함
   
## 못 푼 이유
- 예제 4번에 대한 이해가 부족했음 
  
  : 1과 11을 누르면 난이도가 (13-11+1)이 된다는걸 놓침 
