### PR TITLE
250328_yujin0124

### DIFF
--- a/yujin0124/250328/16234_gold4.py
+++ b/yujin0124/250328/16234_gold4.py
@@ -1,0 +1,51 @@
+import sys
+sys.setrecursionlimit(10**6)
+
+dx = [0, 0, -1, 1]
+dy = [-1, 1, 0, 0]
+
+def make_union(x, y, unions):
+  unions.append([x, y])
+  visited[x][y] = True
+  
+  for i in range(4):
+    nx, ny = x + dx[i], y + dy[i]
+    if nx < 0 or nx >= n or ny < 0 or ny >= n:
+      continue
+    if visited[nx][ny]:
+      continue
+    if l <= abs(populations[x][y] - populations[nx][ny]) <= r:
+      make_union(nx, ny, unions)
+
+n, l, r = map(int, input().split())
+
+populations = []
+for i in range(n):
+  populations.append(list(map(int, input().split())))
+
+day = 0
+while True:
+  visited = [[False] * n for _ in range(n)]
+  check = False
+  for i in range(n):
+    for j in range(n):
+      if not visited[i][j]:
+        unions = []
+        make_union(i, j, unions)
+      
+      if len(unions) <= 1:
+        continue
+      check = True
+      
+      population_sum = 0
+      for x, y in unions:
+        population_sum += populations[x][y]
+      new_population = population_sum // len(unions)
+      for x, y in unions:
+        populations[x][y] = new_population
+  
+  if not check:
+    break
+  day += 1
+        
+print(day)

--- a/yujin0124/250328/6603_silver2.py
+++ b/yujin0124/250328/6603_silver2.py
@@ -1,0 +1,21 @@
+def back(n, x):
+  if n == 6:
+    for i in result:
+      print(i, end=" ")
+    print()
+    return
+  
+  for i in range(x, k):
+    result[n] = arr[i+1]
+    back(n+1, i+1)
+
+while True:
+  arr = list(map(int, input().split()))
+  k = arr[0]
+  if k == 0:
+    break
+  
+  result = [0] * 6
+  back(0, 0)
+  print()
+  


### PR DESCRIPTION
## 6603번 로또 Solved
  + 시간 복잡도 O(k * C(k,6)), 공간 복잡도 O(k)
  + 백트래킹을 사용하였습니다. 입력이 정렬되어 있기 때문에 다음 값을 찾을 때 현재값보다 큰 인덱스를 가지는 값부터 순회하도록 하였습니다.

## 16234번 인구 이동 Solved
  + 시간 복잡도 O(day * n^2), 공간 복잡도 O(n^2)
  + dfs를 사용해서 연합을 구하고 인구 이동하는 과정을 무한 루프로 반복하여 해결했습니다.
  + 모든 칸 순회가 O(n^2), dfs는 최악의 경우 O(n^2)의 연산을 할 수 있지만, visited 배열이 있어 모든 칸이 하루에 한 번 방문되므로 하루 당 연산이 O(n^2)라고 계산했습니다
  + day가 커질수록 시간초과가 발생할 수도 있겠다고 생각했지만 다행히 통과되었습니다! 더 좋은 솔루션이 있을 것 같습니다..