### PR TITLE
250331_yujin0124

### DIFF
--- a/yujin0124/250331/17484_silver3.py
+++ b/yujin0124/250331/17484_silver3.py
@@ -1,0 +1,35 @@
+import sys
+sys.setrecursionlimit(10**6)
+
+n, m = map(int, input().split())
+prices = [list(map(int, input().split())) for _ in range(n)]
+
+dx = [1, 1, 1]
+dy = [-1, 0, 1]
+
+min_price = n * 110
+
+def back(prev, sum, x, y):
+  global min_price
+  
+  sum += prices[x][y]
+  if min_price < sum:
+    return
+  
+  if x >= n-1:
+    min_price = min(min_price, sum)
+    return
+  
+  for i in range(3):
+    if prev == i:
+      continue
+    nx, ny = x + dx[i], y + dy[i]
+    if not(0 <= nx < n and 0 <= ny < m):
+      continue
+    back(i, sum, nx, ny)
+
+
+for i in range(m):
+  back(-1, 0, 0, i)
+
+print(min_price)

--- a/yujin0124/250331/2631_gold4.py
+++ b/yujin0124/250331/2631_gold4.py
@@ -1,0 +1,12 @@
+n = int(input())
+arr = [0] * n
+
+dp = [0] * n
+for i in range(n):
+  arr[i] = int(input())
+  dp[i] = 1
+  for j in range(i):
+    if arr[i] > arr[j]:
+      dp[i] = max(dp[i], dp[j] + 1)
+
+print(n - max(dp))


### PR DESCRIPTION
## 17484번 진우의 달 여행 (Small) Solved
  + 시간 복잡도 O(m * 3^n), 공간 복잡도 O(nm)
  + 백트래킹을 사용하였습니다. 재귀 함수의 인자로 이전 이동 방향, 여태까지의 연료 가격의 합, 이동한 위치를 전달했습니다.
  + 처음에는 dp를 사용하려고 했으나 이전 이동 방향을 기록하는 것이 까다로워 지금의 방식을 선택하였습니다. 최악의 경우 브루트포스와 같아질 수 있으나 n과 m의 크기가 크지 않아 괜찮을 것이라 생각했습니다.

## 2631번 줄세우기 Solved
  + 시간 복잡도 O(n^2), 공간 복잡도 O(n)
  + dp를 사용해 증가하는 부분 수열 중 가장 긴 것을 찾고 나머지를 옮긴다는 의미로 전체 길이에서 빼주고 출력했습니다.