### PR TITLE
250428_yujin0124

### DIFF
--- a/yujin0124/250428/1522_silver1.py
+++ b/yujin0124/250428/1522_silver1.py
@@ -1,0 +1,21 @@
+def sol(s):
+    n = len(s)
+    a_count = s.count('a')
+    
+    if a_count == 0 or a_count == n:
+        return 0
+    
+    min_swap = float('inf')
+    
+    for i in range(n): 
+        swap = 0
+        for j in range(i, i + a_count):
+            if s[j % n] == 'b':
+                swap += 1
+        
+        min_swap = min(min_swap, swap)
+    
+    return min_swap
+
+s = input().strip()
+print(sol(s))

--- a/yujin0124/250428/16928_gold5.py
+++ b/yujin0124/250428/16928_gold5.py
@@ -1,0 +1,41 @@
+from collections import deque
+
+def sol():
+    N, M = map(int, input().split())
+    
+    board = {}
+    
+    for _ in range(N):
+        x, y = map(int, input().split())
+        board[x] = y
+    
+    for _ in range(M):
+        u, v = map(int, input().split())
+        board[u] = v
+    
+    visited = [False] * 101
+    queue = deque([(1, 0)])
+    visited[1] = True
+    
+    while queue:
+        pos, throws = queue.popleft()
+        
+        if pos == 100:
+            return throws
+        
+        for dice in range(1, 7):
+            next_pos = pos + dice
+            
+            if next_pos > 100:
+                continue
+            
+            if next_pos in board:
+                next_pos = board[next_pos]
+            
+            if not visited[next_pos]:
+                visited[next_pos] = True
+                queue.append((next_pos, throws + 1))
+    
+    return -1
+
+print(sol())


### PR DESCRIPTION
## 1522번 문자열 교환 Solved
  + 시간 복잡도 O(n^2) 공간 복잡도 O(n)
  +  전체 a의 개수를 세고 각 자리에서 a의 개수만큼 더한 위치까지 전부 a가 되도록 하려면 몇 번의 교환이 필요한지 구했습니다. 그 중 최솟값을 출력했습니다.
  + 최악의 경우 O(n^2)이지만 n의 최대가 1000으로 많이 크지 않았기 때문에 이렇게 구현해도 시간 초과되지 않겠다고 생각했습니다.

## 12886번 돌 그룹 Missed
  + 시간 복잡도 O(V+E) 공간 복잡도 O(100)
  + bfs를 사용하여 주사위를 던지는 횟수인 throws를 함께 기록하고 가능한 경우의 수들을 큐에 넣어주었습니다. bfs이므로 throws가 증가할 때는 해당 던진 횟수에서 가능한 모든 경우의 수를 고려했을 것이라 생각해 가장 먼저 100이 나올 때를 최소 횟수로 판단하고 출력하게 했습니다. 